### PR TITLE
Search for build.gradle within app_folder_name

### DIFF
--- a/lib/fastlane/plugin/increment_version_code/actions/increment_version_code_action.rb
+++ b/lib/fastlane/plugin/increment_version_code/actions/increment_version_code_action.rb
@@ -14,7 +14,7 @@ module Fastlane
 
         temp_file = Tempfile.new('fastlaneIncrementVersionCode')
         foundVersionCode = "false"
-        Dir.glob("**/#{app_folder_name}/build.gradle") do |path|
+        Dir.glob("#{app_folder_name}/**/build.gradle") do |path|
             UI.message(" -> Found a build.gradle file at path: (#{path})!")
                 begin
                     temp_file = Tempfile.new('fastlaneIncrementVersionCode')


### PR DESCRIPTION
Current globbing has the problem that it is not strict enough. In a React Native project for example, defining `android/app` as `app_folder_name`, it finds all `build.gradle` files contained in any `android/app` directory structure.

For example:
- android/app/build.gradle
- node_modules/node_modules/react-native-calendar/example/android/build.gradle

Ruby 2.2 returns:
- android/app/build.gradle
- node_modules/node_modules/react-native-calendar/example/android/build.gradle

Ruby 2.1 returns:
- node_modules/node_modules/react-native-calendar/example/android/build.gradle
- android/app/build.gradle

and therefore `fastlane-plugin-increment_version_code` modified the wrong build.gradle (it takes only the first result).

This PR tries to fix that, by globbing WITHIN `app_folder_name`.
