### PR TITLE
Allow force set version_code if specified

### DIFF
--- a/lib/fastlane/plugin/increment_version_code/actions/increment_version_code_action.rb
+++ b/lib/fastlane/plugin/increment_version_code/actions/increment_version_code_action.rb
@@ -9,6 +9,13 @@ module Fastlane
         version_code = "0"
         new_version_code ||= params[:version_code]
 
+        # If version_code is set, ignore the process
+        if new_version_code != nil
+          # Store the version name in the shared hash
+          Actions.lane_context["VERSION_CODE"]=new_version_code.to_i
+          UI.success("VERSION_CODE will be forced set to #{new_version_code}")
+          UI.success("☝️ Version code has been changed to #{new_version_code}")
+
         constant_name ||= params[:ext_constant_name]
 
         gradle_file_path ||= params[:gradle_file_path]
@@ -102,7 +109,7 @@ module Fastlane
                                 default_value: nil),
               FastlaneCore::ConfigItem.new(key: :version_code,
                                       env_name: "INCREMENTVERSIONCODE_VERSION_CODE",
-                                   description: "Change to a specific version (optional)",
+                                   description: "Force change to a specific version (optional)",
                                       optional: true,
                                           type: Integer,
                                  default_value: 0),


### PR DESCRIPTION
Hi, thanks for your great work on this plugin!

For context, recently Flutter has been a new player in mobile development. Flutter support for this plugin is great if possible!

In the Flutter app, versionCode is in `build.gradle` and will be programmatically evaluated during the build process as below

```
flutterVersionCode.toInteger()
```

Hence, string manipulation is not possible here.

Also, I think once version_code is explicitly set, it should be the final desired output.

What do you think? @Jems22 Would like to hear your feedback soon !